### PR TITLE
Deprecate apiserver-proxy and iam-kubeconfig

### DIFF
--- a/docs/security/03-04-ingress-egress-traffic.md
+++ b/docs/security/03-04-ingress-egress-traffic.md
@@ -49,7 +49,6 @@ You can install Kyma on top of [Gardener](https://gardener.cloud/) managed insta
 ### API Server Proxy
 
 >**NOTE:** The API Server Proxy component (apiserver-proxy) is entering deprecation phase.
->**NOTE:** The API Server Proxy component (apiserver-proxy) is deprecated.
 
 The [API Server Proxy](https://github.com/kyma-project/kyma/tree/master/components/apiserver-proxy) component is a reverse proxy which acts as an intermediary for the Kubernetes API. By default, it is exposed as a LoadBalancer Service, meaning it requires a dedicated certificate and DNS entry.
 

--- a/docs/security/03-04-ingress-egress-traffic.md
+++ b/docs/security/03-04-ingress-egress-traffic.md
@@ -48,7 +48,7 @@ You can install Kyma on top of [Gardener](https://gardener.cloud/) managed insta
 
 ### API Server Proxy
 
->**NOTE:** The API Server PRoxy component (apiserver-proxy) is deprecated.
+>**NOTE:** The API Server Proxy component (apiserver-proxy) is deprecated.
 
 The [API Server Proxy](https://github.com/kyma-project/kyma/tree/master/components/apiserver-proxy) component is a reverse proxy which acts as an intermediary for the Kubernetes API. By default, it is exposed as a LoadBalancer Service, meaning it requires a dedicated certificate and DNS entry.
 

--- a/docs/security/03-04-ingress-egress-traffic.md
+++ b/docs/security/03-04-ingress-egress-traffic.md
@@ -48,7 +48,7 @@ You can install Kyma on top of [Gardener](https://gardener.cloud/) managed insta
 
 ### API Server Proxy
 
->**NOTE:** The API Server PRoxy component (apiserver-proxy) is deprecated.
+>**NOTE:** The API Server PRoxy component (apiserver-proxy) is entering deprecation phase.
 
 The [API Server Proxy](https://github.com/kyma-project/kyma/tree/master/components/apiserver-proxy) component is a reverse proxy which acts as an intermediary for the Kubernetes API. By default, it is exposed as a LoadBalancer Service, meaning it requires a dedicated certificate and DNS entry.
 

--- a/docs/security/03-04-ingress-egress-traffic.md
+++ b/docs/security/03-04-ingress-egress-traffic.md
@@ -6,19 +6,19 @@ type: Details
 ## Ingress
 
 Kyma uses the [Istio Ingress Gateway](https://istio.io/latest/docs/reference/config/networking/gateway/) to handle all incoming traffic, manage TLS termination, and handle mTLS communication between the cluster and external services. By default, the [`kyma-gateway`](https://github.com/kyma-project/kyma/blob/master/resources/core/charts/gateway/templates/gateway.yaml) configuration defines the points of entry to expose all applications using the supplied domain and certificates.
-Applications are exposed using the [API Gateway](components/api-gateway/#overview-overview) controller. 
+Applications are exposed using the [API Gateway](components/api-gateway/#overview-overview) controller.
 
 The configuration specifies the following parameters and their values:
 
-| Parameter | Description | Value| 
-|-----| ---| -----| 
+| Parameter | Description | Value|
+|-----| ---| -----|
 | **spec.servers.port** | The ports gateway listens on.  Port `80` is automatically redirected to `443`.| `443`, `80`.|
 | **spec.servers.tls.minProtocolVersion** | The minimum protocol version required by the TLS connection. | `TLSV1_2` protocol version. `TLSV1_0` and `TLSV1_1` are rejected. |
 | **spec.servers.tls.cipherSuites** | Accepted cypher suites. | `ECDHE-RSA-CHACHA20-POLY1305`, `ECDHE-RSA-AES256-GCM-SHA384`, `ECDHE-RSA-AES256-SHA`, `ECDHE-RSA-AES128-GCM-SHA256`, `ECDHE-RSA-AES128-SHA`|
 
 ## TLS management
 
-Kyma employs the Bring Your Own Domain/Certificates model that requires you to supply the certificate and key during installation. You can do it using the [Helm overrides for Kyma installation](/root/kyma/#configuration-helm-overrides-for-kyma-installation). See a sample ConfigMap specifying the values to override: 
+Kyma employs the Bring Your Own Domain/Certificates model that requires you to supply the certificate and key during installation. You can do it using the [Helm overrides for Kyma installation](/root/kyma/#configuration-helm-overrides-for-kyma-installation). See a sample ConfigMap specifying the values to override:
 
 ```yaml
 ---
@@ -34,7 +34,7 @@ data:
   global.tlsCrt: "CERT"
   global.tlsKey: "CERT_KEY"
 ```
-During installation, the values are [propagated in the cluster](#certificate-propagation-paths) to all components that require them. 
+During installation, the values are [propagated in the cluster](#certificate-propagation-paths) to all components that require them.
 
 ### Demo setup with xip.io
 
@@ -48,6 +48,8 @@ You can install Kyma on top of [Gardener](https://gardener.cloud/) managed insta
 
 ### API Server Proxy
 
+>**NOTE:** The API Server PRoxy component (apiserver-proxy) is deprecated.
+
 The [API Server Proxy](https://github.com/kyma-project/kyma/tree/master/components/apiserver-proxy) component is a reverse proxy which acts as an intermediary for the Kubernetes API. By default, it is exposed as a LoadBalancer Service, meaning it requires a dedicated certificate and DNS entry.
 
 To learn more about about API Server Proxy configuration, see the [configuration section](/components/security/#configuration-api-server-proxy-chart).
@@ -60,9 +62,9 @@ The certificate data is propagated though Kyma and delivered to several componen
 
 1. Kyma Installer reads the override files you have configured.
 2. Kyma installer passes the values to the specific Kyma components.
-3. Each of these components generates Secrets, ConfigMaps, and Certificates in a certain order. 
+3. Each of these components generates Secrets, ConfigMaps, and Certificates in a certain order.
 
-The table shows the order in which the configuration elements are created. 
+The table shows the order in which the configuration elements are created.
 
 >**NOTE:** The table does not include all possible dependencies between the components and elements that use the certificates. It serves as a reference to know where to find information about the certificates and configurations.
 
@@ -74,38 +76,38 @@ The order differs depending on the mode:
   Bring Your Own Certificate
   </summary>
   | **Kind** | **Name** | **Namespace** |
-  | :--- | :--- | :--- | 
+  | :--- | :--- | :--- |
   | Secret | ingress-tls-cert | `kyma-system` |
-  | ConfigMap | net-global-overrides | `kyma-installer `| 
+  | ConfigMap | net-global-overrides | `kyma-installer `|
   | Secret | kyma-gateway-certs | `istio-system` |
   | Secret | kyma-gateway-certs-cacert | `istio-system `|
-  | Secret | apiserver-proxy-tls-cert | `kyma-system` | 
-  | ConfigMap | apiserver-proxy | `kyma-system `|  
+  | Secret | apiserver-proxy-tls-cert | `kyma-system` |
+  | ConfigMap | apiserver-proxy | `kyma-system `|
   </details>
   <details>
   <summary label="demo-xip">
   Demo xip.io setup
   </summary>
   | **Kind** | **Name** | **Namespace** |
-  | :--- | :--- | :--- | 
+  | :--- | :--- | :--- |
   | Secret | ingress-tls-cert | `kyma-system` |
-  | ConfigMap | net-global-overrides | `kyma-installer `| 
+  | ConfigMap | net-global-overrides | `kyma-installer `|
   | Secret | kyma-gateway-certs | `istio-system` |
   | Secret | kyma-gateway-certs-cacert | `istio-system `|
-  | Secret | apiserver-proxy-tls-cert | `kyma-system` | 
-  | ConfigMap | apiserver-proxy | `kyma-system `|  
+  | Secret | apiserver-proxy-tls-cert | `kyma-system` |
+  | ConfigMap | apiserver-proxy | `kyma-system `|
   </details>
   <details>
   <summary label="gardener">
-  Gardener-managed 
+  Gardener-managed
   </summary>
   | **Kind** | **Name** | **Namespace** |
-  | :--- | :--- | :--- | 
+  | :--- | :--- | :--- |
   | Secret | ingress-tls-cert | `kyma-system `|
-  | ConfigMap | net-global-overrides | `kyma-installer `| 
+  | ConfigMap | net-global-overrides | `kyma-installer `|
   | Secret | kyma-gateway-certs-cacert | `istio-system` |
   | Certificate | kyma-tls-cert | `istio-system`|
-  | Certificate | apiserver-proxy-tls-cert | `kyma-system` | 
+  | Certificate | apiserver-proxy-tls-cert | `kyma-system` |
   |ConfigMap | apiserver-proxy | `kyma-system` |
    </details>
 </div>
@@ -113,4 +115,4 @@ The order differs depending on the mode:
 ## Egress
 Currently no Egress limitations are implemented, meaning that all applications deployed in the Kyma cluster can access outside resources without limitations.
 
->**NOTE:** in the case of connection problems with external services it may be required to create an [Service Entry](https://istio.io/latest/docs/reference/config/networking/service-entry/) object to register the service. 
+>**NOTE:** in the case of connection problems with external services it may be required to create an [Service Entry](https://istio.io/latest/docs/reference/config/networking/service-entry/) object to register the service.

--- a/docs/security/05-01-api-server-proxy.md
+++ b/docs/security/05-01-api-server-proxy.md
@@ -3,7 +3,7 @@ title: API Server Proxy chart
 type: Configuration
 ---
 
->**CAUTION:** The API Server PRoxy component (apiserver-proxy) is deprecated.
+>**CAUTION:** The API Server PRoxy component (apiserver-proxy) is entering deprecation phase - a simpler solution is planned.
 
 To configure the API Server Proxy chart, override the default values of its `values.yaml` file. This document describes parameters that you can configure.
 

--- a/docs/security/05-01-api-server-proxy.md
+++ b/docs/security/05-01-api-server-proxy.md
@@ -3,6 +3,8 @@ title: API Server Proxy chart
 type: Configuration
 ---
 
+>**CAUTION:** The API Server PRoxy component (apiserver-proxy) is deprecated.
+
 To configure the API Server Proxy chart, override the default values of its `values.yaml` file. This document describes parameters that you can configure.
 
 >**TIP:** To learn more about how to use overrides in Kyma, see the following documents:

--- a/docs/security/05-01-api-server-proxy.md
+++ b/docs/security/05-01-api-server-proxy.md
@@ -3,7 +3,7 @@ title: API Server Proxy chart
 type: Configuration
 ---
 
->**CAUTION:** The API Server Proxy component (apiserver-proxy) is entering deprecation phase - a simpler solution is planned.
+>**CAUTION:** The API Server Proxy component (apiserver-proxy) is deprecated and will be replaced with a different mechanism.
 
 To configure the API Server Proxy chart, override the default values of its `values.yaml` file. This document describes parameters that you can configure.
 

--- a/docs/security/05-01-api-server-proxy.md
+++ b/docs/security/05-01-api-server-proxy.md
@@ -3,7 +3,7 @@ title: API Server Proxy chart
 type: Configuration
 ---
 
->**CAUTION:** The API Server PRoxy component (apiserver-proxy) is deprecated.
+>**CAUTION:** The API Server Proxy component (apiserver-proxy) is deprecated.
 
 To configure the API Server Proxy chart, override the default values of its `values.yaml` file. This document describes parameters that you can configure.
 

--- a/docs/security/05-02-iam-kubeconfig-service.md
+++ b/docs/security/05-02-iam-kubeconfig-service.md
@@ -3,7 +3,7 @@ title: IAM Kubeconfig Service chart
 type: Configuration
 ---
 
->**CAUTION:** The IAM Kubeconfig component (iam-kubeconfig) is deprecated.
+>**CAUTION:** The IAM Kubeconfig component (iam-kubeconfig) is entering deprecation phase - a simpler solution is planned.
 
 To configure the IAM Kubeconfig Service chart, override the default values of its `values.yaml` file. This document describes parameters that you can configure.
 

--- a/docs/security/05-02-iam-kubeconfig-service.md
+++ b/docs/security/05-02-iam-kubeconfig-service.md
@@ -3,7 +3,7 @@ title: IAM Kubeconfig Service chart
 type: Configuration
 ---
 
->**CAUTION:** The IAM Kubeconfig component (iam-kubeconfig) is entering deprecation phase - a simpler solution is planned.
+>**CAUTION:** The IAM Kubeconfig component (iam-kubeconfig) is deprecated and will be replaced with a different mechanism.
 
 To configure the IAM Kubeconfig Service chart, override the default values of its `values.yaml` file. This document describes parameters that you can configure.
 

--- a/docs/security/05-02-iam-kubeconfig-service.md
+++ b/docs/security/05-02-iam-kubeconfig-service.md
@@ -3,6 +3,8 @@ title: IAM Kubeconfig Service chart
 type: Configuration
 ---
 
+>**CAUTION:** The IAM Kubeconfig component (iam-kubeconfig) is deprecated.
+
 To configure the IAM Kubeconfig Service chart, override the default values of its `values.yaml` file. This document describes parameters that you can configure.
 
 >**TIP:** To learn more about how to use overrides in Kyma, see the following documents:


### PR DESCRIPTION
**Description**

Add deprecation note to apiserver-proxy and iam-kubeconfig services docs.

Changes proposed in this pull request:

- Deprecate apiserver-proxy
- Deprecate iam-kubeconfig

**Related issue(s)**
See also: https://github.com/kyma-project/kyma/pull/9323